### PR TITLE
Use "future" for compatibility Python2

### DIFF
--- a/octoprint_freemobilenotifier/__init__.py
+++ b/octoprint_freemobilenotifier/__init__.py
@@ -5,11 +5,9 @@ import os
 import sys
 import octoprint.plugin
 
-PY3 = sys.version_info[0] == 3
-if PY3:
-	import urllib.request
-else:
-	import urllib2
+from future import standard_library
+standard_library.install_aliases()
+from urllib import request,parse
 
 class FreemobilenotifierPlugin(octoprint.plugin.EventHandlerPlugin,
                                octoprint.plugin.SettingsPlugin,
@@ -49,16 +47,13 @@ class FreemobilenotifierPlugin(octoprint.plugin.EventHandlerPlugin,
 		elapsed_time = octoprint.util.get_formatted_timedelta(datetime.timedelta(seconds=payload["time"]))
 
 		tags = {'filename': filename, 'elapsed_time': elapsed_time}
-		message = self._settings.get(["message_format", "body"]).format(**tags)
+		message = parse.quote(self._settings.get(["message_format", "body"]).format(**tags))
 		login = self._settings.get(["login"])
 		pass_key = self._settings.get(["pass_key"])
 		url = 'https://smsapi.free-mobile.fr/sendmsg?&user='+login+'&pass='+pass_key+'&msg='+message
 
 		try:
-			if PY3:
-				urllib.request.urlopen(url)
-			else:
-				urllib2.urlopen(urllib2.Request(url))
+				request.urlopen(url)
 		except Exception as e:
 			# report problem sending sms
 			self._logger.exception("SMS notification error: %s" % (str(e)))

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ plugin_url = "https://github.com/Pinaute/OctoPrint_FreeMobile-Notifier"
 plugin_license = "AGPLv3"
 
 # Any additional requirements besides OctoPrint should be listed here
-plugin_requires = []
+plugin_requires = ["future>=0.18.2"]
 
 ### --------------------------------------------------------------------------------------------------------------------
 ### More advanced options that you usually shouldn't have to touch follow after this point


### PR DESCRIPTION
To increase Python2/Python3 compatibility, changed code to use "future" package. Tested with Python 2 and 3.

#4 